### PR TITLE
Add Jinja2 Filters for Converting among DNs and Hostnames

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,8 +240,13 @@ J2 Filters
   ```
 
 
-
 License
--------
+=======
 
 BSD
+
+
+Contributors
+============
+
+Pavel Penev <https://github.com/tst-ppenev>: Minor contributions, such as J2 filters.

--- a/README.md
+++ b/README.md
@@ -211,6 +211,36 @@ Example Playbook
         - dbservers
 ```
 
+
+LDAP Filter Plugin
+==================
+
+This role provides a few simple Ansible Jinja2 filters for working with
+LDAP names.
+
+J2 Filters
+----------
+
+* `hostname_to_dn`: Converts a hostname string into a Distinguished Name
+  string.
+  
+  E.g.:
+  ```yaml
+  server_hostname: some.corp.com
+  server_dn: {{ server_hostname | hostname_to_dn }}  # Set 'server_dn' to 'dc=some,dc=corp,dc=com'.
+  ```
+
+* `dn_to_hostname`: Converts a Distinguished Name string of Domain Components
+  into a hostname string.
+  
+  E.g.:
+  ```yaml
+  server_dn: DC=some,DC=corp,DC=com
+  server_hostname: {{ server_dn | dn_to_hostname }}  # Set 'server_hostname' to 'some.corp.com'.
+  ```
+
+
+
 License
 -------
 

--- a/filter_plugins/hostname_dn.py
+++ b/filter_plugins/hostname_dn.py
@@ -1,0 +1,52 @@
+# Copyright (C) 2016, Pavel Penev
+#
+# This file is contributed to the `lookup_ldap` Ansible role.
+# It can be used under BSD, or ISC license.
+#
+# Permission to use, copy, modify, and/or distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+# SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
+# OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+# CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+
+import ldap.dn
+
+def hostname_to_dn(arg):
+    """Convert a hostname string into a Distinguished Name string.
+
+    E.g.:
+
+    >>> hostname_to_dn('some.corp.com')
+    'dc=some,dc=corp,dc=com'
+    """
+    rdnComponents = [[('dc', name, 1)] for name in arg.split('.')]
+
+    return ldap.dn.dn2str(rdnComponents)
+
+def dn_to_hostname(arg):
+    """Convert a Distinguished Name string of Domain Components into a hostname string.
+
+    >>> dn_to_hostname('DC=some,DC=corp,DC=com')
+    'some.corp.com'
+    """
+
+    dcValues = [[rdnValue for (rdnType, rdnValue, _) in rdnLevel if rdnType.lower() == 'dc'][0]
+                for rdnLevel in ldap.dn.str2dn(arg)];
+
+    return '.'.join(dcValues)
+
+
+# Declare the available filters to Ansible:
+class FilterModule(object):
+    def filters(self):
+        return {
+            'hostname_to_dn': hostname_to_dn,
+            'dn_to_hostname': dn_to_hostname
+        }


### PR DESCRIPTION
- Added two new Jinja 2 filters:
  - `{{ 'some.corp.com' | hostname_to_dn }}` is equivalent to `'dc=some,dc=corp,dc=com'`.
  - `{{ 'DC=some,DC=corp,DC=com' | dn_to_hostname }}` is equivalent to `'some.corp.com'`.
- Added a 'Contributors' section to <README.md>.
