### PR TITLE
Cast "bindpw" to unicode to handle Ansible vault

### DIFF
--- a/lookup_plugins/ldap.py
+++ b/lookup_plugins/ldap.py
@@ -169,6 +169,9 @@ class LookupModule(LookupBase):
                 auth_tokens = ldap.sasl.gssapi()
                 lo.sasl_interactive_bind_s('', auth_tokens)
             else:
+                # bindpw may be an AnsibleVaultEncryptedUnicode, which ldap doesn't
+                # know anything about, so cast to unicode explicitly now.
+                
                 lo.simple_bind_s(ctx.get('binddn', ''), unicode(ctx.get('bindpw', '')))
 
         ret = []

--- a/lookup_plugins/ldap.py
+++ b/lookup_plugins/ldap.py
@@ -169,7 +169,7 @@ class LookupModule(LookupBase):
                 auth_tokens = ldap.sasl.gssapi()
                 lo.sasl_interactive_bind_s('', auth_tokens)
             else:
-                lo.simple_bind_s(ctx.get('binddn', ''), ctx.get('bindpw', ''))
+                lo.simple_bind_s(ctx.get('binddn', ''), unicode(ctx.get('bindpw', '')))
 
         ret = []
 


### PR DESCRIPTION
Hi,

This PR prevents Ansible vault-encrypted bind passwords to throw the following error:
```
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/site-packages/ansible/executor/task_executor.py", line 88, in run
    items = self._get_loop_items()
  File "/usr/local/lib/python2.7/site-packages/ansible/executor/task_executor.py", line 221, in _get_loop_items
    items = mylookup.run(terms=loop_terms, variables=self._job_vars, wantlist=True)
  File "…/plugins/lookup/ldap.py", line 172, in run
    lo.simple_bind_s(ctx.get('binddn', ''), ctx.get('bindpw', ''))
  File "/usr/local/lib/python2.7/site-packages/ldap/ldapobject/simple.py", line 273, in simple_bind_s
    msgid = self.simple_bind(who, cred, serverctrls, clientctrls)
  File "/usr/local/lib/python2.7/site-packages/ldap/ldapobject/simple.py", line 260, in simple_bind
    RequestControlTuples(clientctrls)
  File "/usr/local/lib/python2.7/site-packages/ldap/ldapobject/simple.py", line 91, in _ldap_call
    result = func(*args, **kwargs)
TypeError: argument 2 must be string or read-only buffer, not AnsibleVaultEncryptedUnicode
```

Let me know if this change suits you.

Regards,
Vincent