### PR TITLE
Allow automatic expansion of list terms

### DIFF
--- a/lookup_plugins/ldap.py
+++ b/lookup_plugins/ldap.py
@@ -97,7 +97,8 @@ class LookupModule(LookupBase):
         if not isinstance(terms, list):
             terms = [terms]
         for term in terms[:]:
-            if isinstance(terms, list):
+            if isinstance(term, list):
+                del terms[terms.index(term)]
                 terms += term
 
         ctx = {}

--- a/lookup_plugins/ldap.py
+++ b/lookup_plugins/ldap.py
@@ -96,6 +96,9 @@ class LookupModule(LookupBase):
     def run(self, terms, variables=None, **kwargs):
         if not isinstance(terms, list):
             terms = [terms]
+        for term in terms[:]:
+            if isinstance(terms, list):
+                terms += term
 
         ctx = {}
         while len(terms) > 0 and isinstance(terms[0], dict):


### PR DESCRIPTION
Hi there,

There's a mild oversight in this plugin. If you want to pass in a list of terms from e.g. a variable, then you'd do so like so:

  vars:
    users:
    - usera
    - userb
    ldap_lookup_config:
      url: ldaps://myldap
      base: DC=my,DC=site
      binddn: "abind@mysite"
      bindpw: "apwd"
    my_ctx:
      base: DC=my,DC=site
      key: term
      value: mail
      filter: (cn={{ term }})

  - name: "Test LDAP Lookup"
    debug: msg="{{ item }}"
    with_ldap:
      - context: my_ctx
      - "{{ users }}"

However, without this PR the ldap function will simply flatten the users list into a string, and attempt to lookup like so:

LDAP search, expanded: {u'binddn': u'abind@mysite', 'context': {u'binddn': u'abind@mysite', u'key': u'cn', u'url': u'ldaps://myldap', u'value': u'mail', u'filter': u"(cn=[u'usera', u'userb'])", u'base': u'DC=my,DC=site', u'bindpw': u'apwd', 'context': {u'url': u'ldaps://myldap', u'binddn': u'abind@mysite', u'base': u'DC=my,DC=site', u'bindpw': u'apwd'}}, u'url': u'ldaps://myldap', u'value': u'mail', 'filter': u"(cn=[u'usera', u'userb'])", 'base': u'DC=my,DC=site', u'bindpw': u'apwd', 'wantlist': True, u'key': u'cn', 'scope': 'subtree'}

This PR pulls in any list terms into the main terms list, allowing full iteration.