### PR TITLE
lookup_ldap: make Python 3.7 and Python 2.7 compatible.

### DIFF
--- a/lookup_plugins/ldap.py
+++ b/lookup_plugins/ldap.py
@@ -1,3 +1,6 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
 # Copyright (C) 2014, Thomas Quinot
 #
 # This file is part of Ansible
@@ -74,6 +77,8 @@ def encode(p, v):
         v = base64.b64encode(v)
     elif e is not None:
         v = v.decode(e)
+    else:
+        v = v.decode()
     return v
 
 
@@ -142,7 +147,7 @@ class LookupModule(LookupBase):
 
         try:
             ctx = self.render_template(variables, ctx)
-        except Exception, e:
+        except Exception as  e:
             raise errors.AnsibleError(
                 'exception while preparing LDAP parameters: %s' % e)
         self._display.vv("LDAP config: %s" % hide_pw(ctx))
@@ -166,7 +171,7 @@ class LookupModule(LookupBase):
                         attr_props[attr_name] = attr_prop_dict
 
             base_args['attrlist'] = \
-                [a.encode('ASCII') for a in attr_props
+                [a for a in attr_props
                  if attr_props[a] is None
                  or not attr_props[a].get('skip', False)]
 
@@ -196,7 +201,7 @@ class LookupModule(LookupBase):
                 # bindpw may be an AnsibleVaultEncryptedUnicode, which ldap doesn't
                 # know anything about, so cast to unicode explicitly now.
 
-                lo.simple_bind_s(ctx.get('binddn', ''), unicode(ctx.get('bindpw', '')))
+                lo.simple_bind_s(ctx.get('binddn', ''), str(ctx.get('bindpw', '')))
 
         ret = []
 


### PR DESCRIPTION
Actually rebased abandoned #21, but without `builtins`.
Tested with Ansible 2.7.4 (I cut sensitive debug information).

Test data:
```yaml
---
- name: jedi
  become: false
  gather_facts: fasle
  remote_user: k0ste
  no_log: false
  strategy: free
  hosts: 127.0.0.1
  tasks:
  - name: get_user_cisco
    debug:
      msg: "{{ item }}"
    with_ldap:
    - context: 'ldap_get_user'
    - value:
      - displayName
      - givenName
    - 'cisco'
  - name: get_user_bender_unicode
    debug:
      msg: "{{ item }}"
    with_ldap:
    - context: 'ldap_get_user'
    - value:
      - displayName: encoding=utf-8
      - givenName: encoding=utf-8
    - 'bender'
  - name: get_user_bender_cn_unicode
    debug:
      msg: "{{ item.cn }}"
    with_ldap:
    - context: 'ldap_get_user'
    - value:
      - cn: encoding=utf-8
      - displayName: encoding=utf-8
      - givenName: encoding=utf-8
    - 'bender'
```

Result, python 2.7.15:
```python
ansible-playbook 2.7.4
  config file = /home/k0ste/ansible-fork/ansible.cfg
  configured module search path = [u'/home/k0ste/ansible/my_modules', u'/home/k0ste/ceph-ansible/library']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible-playbook
  python version = 2.7.15 (default, Jun 27 2018, 13:05:28) [GCC 8.1.1 20180531]
Using /home/k0ste/ansible-fork/ansible.cfg as config file
setting up inventory plugins
/home/k0ste/ansible-fork/inventory did not meet host_list requirements, check plugin documentation if this is unexpected
/home/k0ste/ansible-fork/inventory did not meet script requirements, check plugin documentation if this is unexpected
Parsed /home/k0ste/ansible-fork/inventory inventory source with ini plugin
Loading callback plugin default of type stdout, v2.0 from /usr/lib/python2.7/site-packages/ansible/plugins/callback/default.py
Loading callback plugin installer_checkpoint of type aggregate, v2.0 from /home/k0ste/ceph-ansible/plugins/callback/installer_checkpoint.pyc

PLAYBOOK: test.yml *************************************************************************************************************************************************************************************************
1 plays in test.yml

PLAY [jedi] ********************************************************************************************************************************************************************************************************

TASK [get_user_cisco] **********************************************************************************************************************************************************************************************
task path: /home/k0ste/ansible-fork/test.yml:10
ok: [127.0.0.1] => (item={'dn': u'cn=cisco,ou=people,dc=opentech,dc=local', 'term': u'cisco', 'givenName': u'Systems Inc', 'displayName': u'Cisco Systems Inc'}) => {
    "msg": {
        "displayName": "Cisco Systems Inc", 
        "dn": "cn=cisco,ou=people,dc=opentech,dc=local", 
        "givenName": "Systems Inc", 
        "term": "cisco"
    }
}

TASK [get_user_bender_unicode] *************************************************************************************************************************************************************************************
task path: /home/k0ste/ansible-fork/test.yml:19
ok: [127.0.0.1] => (item={'dn': u'cn=\u0420\u043e\u0434\u0440\u0438\u0433\u0435\u0441 \u0411\u0435\u043d\u0434\u0435\u0440 \u0421\u0433\u0438\u0431\u0430\u043b\u044c\u0449\u0438\u043a,ou=people,dc=opentech,dc=local', 'term': u'bender', 'givenName': u'\u0411\u0435\u043d\u0434\u0435\u0440 \u0421\u0433\u0438\u0431\u0430\u043b\u044c\u0449\u0438\u043a', 'displayName': u'\u0420\u043e\u0434\u0440\u0438\u0433\u0435\u0441 \u0411\u0435\u043d\u0434\u0435\u0440 \u0421\u0433\u0438\u0431\u0430\u043b\u044c\u0449\u0438\u043a'}) => {
    "msg": {
        "displayName": "Родригес Бендер Сгибальщик", 
        "dn": "cn=Родригес Бендер Сгибальщик,ou=people,dc=opentech,dc=local", 
        "givenName": "Бендер Сгибальщик", 
        "term": "bender"
    }
}

TASK [get_user_bender_cn_unicode] **********************************************************************************************************************************************************************************
task path: /home/k0ste/ansible-fork/test.yml:28
ok: [127.0.0.1] => (item={'dn': u'cn=\u0420\u043e\u0434\u0440\u0438\u0433\u0435\u0441 \u0411\u0435\u043d\u0434\u0435\u0440 \u0421\u0433\u0438\u0431\u0430\u043b\u044c\u0449\u0438\u043a,ou=people,dc=opentech,dc=local', 'term': u'bender', 'givenName': u'\u0411\u0435\u043d\u0434\u0435\u0440 \u0421\u0433\u0438\u0431\u0430\u043b\u044c\u0449\u0438\u043a', 'displayName': u'\u0420\u043e\u0434\u0440\u0438\u0433\u0435\u0441 \u0411\u0435\u043d\u0434\u0435\u0440 \u0421\u0433\u0438\u0431\u0430\u043b\u044c\u0449\u0438\u043a', 'cn': u'\u0420\u043e\u0434\u0440\u0438\u0433\u0435\u0441 \u0411\u0435\u043d\u0434\u0435\u0440 \u0421\u0433\u0438\u0431\u0430\u043b\u044c\u0449\u0438\u043a'}) => {
    "msg": "Родригес Бендер Сгибальщик"
}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************************************************************************************************************************************************
127.0.0.1                  : ok=3    changed=0    unreachable=0    failed=0   
```

Result, python 3.7.1:
```python
ansible-playbook 2.7.4
  config file = /home/k0ste/ansible-fork/ansible.cfg
  configured module search path = ['/home/k0ste/ansible/my_modules', '/home/k0ste/ceph-ansible/library']
  ansible python module location = /usr/lib/python3.7/site-packages/ansible
  executable location = /usr/bin/ansible-playbook
  python version = 3.7.1 (default, Oct 22 2018, 10:41:28) [GCC 8.2.1 20180831]
Using /home/k0ste/ansible-fork/ansible.cfg as config file
setting up inventory plugins
/home/k0ste/ansible-fork/inventory did not meet host_list requirements, check plugin documentation if this is unexpected
/home/k0ste/ansible-fork/inventory did not meet script requirements, check plugin documentation if this is unexpected
Parsed /home/k0ste/ansible-fork/inventory inventory source with ini plugin
Loading callback plugin default of type stdout, v2.0 from /usr/lib/python3.7/site-packages/ansible/plugins/callback/default.py
Loading callback plugin installer_checkpoint of type aggregate, v2.0 from /home/k0ste/ceph-ansible/plugins/callback/installer_checkpoint.py

PLAYBOOK: test.yml ***********************************************************************************************************************************
1 plays in test.yml

PLAY [jedi] ******************************************************************************************************************************************

TASK [get_user_cisco] ********************************************************************************************************************************
task path: /home/k0ste/ansible-fork/test.yml:10
ok: [127.0.0.1] => (item={'term': 'cisco', 'dn': 'cn=cisco,ou=people,dc=opentech,dc=local', 'givenName': 'Systems Inc', 'displayName': 'Cisco Systems Inc'}) => {
    "msg": {
        "displayName": "Cisco Systems Inc",
        "dn": "cn=cisco,ou=people,dc=opentech,dc=local",
        "givenName": "Systems Inc",
        "term": "cisco"
    }
}

TASK [get_user_bender_unicode] ***********************************************************************************************************************
task path: /home/k0ste/ansible-fork/test.yml:19
ok: [127.0.0.1] => (item={'term': 'bender', 'dn': 'cn=Родригес Бендер Сгибальщик,ou=people,dc=opentech,dc=local', 'givenName': 'Бендер Сгибальщик', 'displayName': 'Родригес Бендер Сгибальщик'}) => {
    "msg": {
        "displayName": "Родригес Бендер Сгибальщик",
        "dn": "cn=Родригес Бендер Сгибальщик,ou=people,dc=opentech,dc=local",
        "givenName": "Бендер Сгибальщик",
        "term": "bender"
    }
}

TASK [get_user_bender_cn_unicode] ********************************************************************************************************************
task path: /home/k0ste/ansible-fork/test.yml:28
ok: [127.0.0.1] => (item={'term': 'bender', 'dn': 'cn=Родригес Бендер Сгибальщик,ou=people,dc=opentech,dc=local', 'givenName': 'Бендер Сгибальщик', 'cn': 'Родригес Бендер Сгибальщик', 'displayName': 'Родригес Бендер Сгибальщик'}) => {
    "msg": "Родригес Бендер Сгибальщик"
}
META: ran handlers
META: ran handlers

PLAY RECAP *******************************************************************************************************************************************
127.0.0.1                  : ok=3    changed=0    unreachable=0    failed=0   
```
