### PR TITLE
Add support for python 3

### DIFF
--- a/lookup_plugins/ldap.py
+++ b/lookup_plugins/ldap.py
@@ -27,6 +27,7 @@ import base64
 import ldap
 import ldap.sasl
 import threading
+import six
 
 default_context = 'ldap_lookup_config'
 
@@ -74,6 +75,8 @@ def encode(p, v):
         v = base64.b64encode(v)
     elif e is not None:
         v = v.decode(e)
+    else:
+        v = v.decode('ASCII')
     return v
 
 
@@ -142,7 +145,7 @@ class LookupModule(LookupBase):
 
         try:
             ctx = self.render_template(variables, ctx)
-        except Exception, e:
+        except Exception as e:
             raise errors.AnsibleError(
                 'exception while preparing LDAP parameters: %s' % e)
         self._display.vv("LDAP config: %s" % hide_pw(ctx))
@@ -196,7 +199,7 @@ class LookupModule(LookupBase):
                 # bindpw may be an AnsibleVaultEncryptedUnicode, which ldap doesn't
                 # know anything about, so cast to unicode explicitly now.
 
-                lo.simple_bind_s(ctx.get('binddn', ''), unicode(ctx.get('bindpw', '')))
+                lo.simple_bind_s(ctx.get('binddn', ''), six.text_type(ctx.get('bindpw', '')))
 
         ret = []
 
@@ -277,7 +280,7 @@ class LookupModule(LookupBase):
 
     @staticmethod
     def get_ldap_constant_value(value_specifier, constant_name_prefix):
-        if isinstance(value_specifier, basestring):
+        if isinstance(value_specifier, six.string_types):
             return getattr(ldap, constant_name_prefix + value_specifier.upper())
         else:
             return value_specifier


### PR DESCRIPTION
This plugin currently crashes under python 3 for several reasons related
to string encoding.

In python 3 the unicode type no longer exists and is simply the type
str. As of Ansible 2.5 Ansible now supports the use of python 3 and this
module currently fails if invoked under python 3 because the unicode
function no longer exists.

Six provides a compatibility layer to support both python 2.7 and python
3. Using six.text_type works safely in both python versions.

Additionally the encode function currently returns the raw string if no
encoding is set which results in a string returned to ansible prefixed
with a b which breaks compatibility with dictionary processing in
Ansible. Instead this now defaults to ASCII to return ASCII strings.